### PR TITLE
Added description for Hannover 2016 based on Koeln

### DIFF
--- a/hannover/index.html
+++ b/hannover/index.html
@@ -1,0 +1,40 @@
+---
+layout: city
+name: Hannover
+eventTitle: Hannover2016
+title: Hannover Open Data Day
+lat: 52.3982128
+lng: 9.7705562
+where: Zühlke Engineering | Pelikanplatz 35, 30177 Hannover
+when: 'Samstag, 5. März | 9:00 - 19:00 Uhr
+<br>Anmeldung:<a href="https://www.eventbrite.de/e/open-data-day-2016-zuhlke-hannover-tickets-20998392758">Eventbrite</a> oder <a href="https://www.xing.com/events/new?sc_o=EV4984_org_ev">Xing</a>'
+tags:
+- event
+published: true
+---
+<h3>Open Data Day in Hannover</h3>
+<p>Am 5. März 2015 ist <a href="de.opendataday.org">Open Data Day</a> und es wird auf Events rund um den Globus mit offenen Daten gearbeitet. In Hannover richtet <a href="http://www.zuehlke.com/de/de">Zühlke Engineering</a> den Open Data Day aus. Treffpunkt ist das Zühlke Büro am Pelikanplatz 35, 30177 Hannover. <a href="https://maps.google.com/?daddr=Pelikanplatz+35+30177+Hannover">Anfahrt</a> </p>
+<p> Ziel ist es, die Bekanntheit von Open Data zu steigern, weitere Daten zu öffnen und zu zeigen, welches Potenzial in offenen Daten steckt. Gemeinsam mit der Stadt Köln können technisch versierte, gestalterisch begabte oder einfach interessierte BürgerInnen gemeinsam Daten so aufbereiten, dass sie einen Mehrwert für MitbürgerInnen darstellen.</p>
+
+<h2> Agenda</h2>
+<ul><li>  9:00 -  9:30 Registration, ankommen, networking, KAFFEE &amp; SNACKS</li>
+<li>  9:30 -  9:45 Begrüßung</li>
+<li>  9:45 - 10:30 Kurzvorstellung der Themen</li>
+<li> 10:30 - 18:00 Hacken, analysieren, visualisieren, umsetzen und alle was man sonst mit offenen Daten machen kann...</li>
+<li> 18:00 - 19:00 Vorstellung der Projekte und Feedback</li>
+<li> 19:00 -       Networking</li></ul>
+
+<h2>Darum kümmern wir uns:</h2>
+<ul><li> WiFi</li>
+<li> Kaffe, Erfrischungen und Snacks</li>
+<li> Zühlke Entwickler mit Erfahrung in Data Science, Big Bata, App/Web/Embedded Entwicklung sind den ganzen Tag dabei.</li></ul>
+<h2>Wen wir suchen:</h2>
+<ul><li> DICH, wenn du gerne etwas mit offenen Daten machen möchtest!</li></ul>
+
+<h2>Ziel</h2>
+<p>Das übergeordnete Ziel der Veranstaltung ist es, so viele Leute wie möglich zu versammeln, sich auszutauschen, zu experimentieren, Anwendungen und Visualisierungen rund um offene Daten zu entwickeln und vor allen Dingen Spaß zu haben.</p>
+
+<br>
+<!-- This is a horrible layout jumping hack, sorry -->
+</div>
+</div>


### PR DESCRIPTION
2016 wird Zühlke Hannover ein Open Data Day Hackathon ausrichten. Ich hoffe ich habe ihn richtig eingetragen. 
